### PR TITLE
fix: correct typo that prevents GX from running correctly in script mode

### DIFF
--- a/examples/seldir/seldir.gxc
+++ b/examples/seldir/seldir.gxc
@@ -58,7 +58,7 @@ real rDir, rTestDir, rError;
 {
    // --- Selection mode ---
 
-   iSelect = iGetInt_SYS("SELDIR", "SELCTION");
+   iSelect = iGetInt_SYS("SELDIR", "SELECTION");
    if (iSelect != 0)
       iSelect = 1;
 


### PR DESCRIPTION
When a script that uses seldir.gx is recorded, the script creates the variable SELDIR.SELECTION in the script file. But this variable is ignored when the script file is run because due to a typo seldir.gx looks for the variable SELDIR.SELCTION. This typo should be corrected to get the expected behavior.